### PR TITLE
Fix simplified Chinese and Korean sans-serif fallback problem

### DIFF
--- a/dev/scss/common/_common.scss
+++ b/dev/scss/common/_common.scss
@@ -3,7 +3,7 @@
 }
 
 .r6-like-font {
-  font-family: 'Open Sans Condensed', sans-serif;
+  font-family: 'Open Sans Condensed', 'Noto Sans SC', 'Noto Sans KR', sans-serif;
   font-weight: 700;
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>R6Maps.com</title>
     <link href='https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700' rel='stylesheet' type='text/css'>
+    <link href="https://fonts.googleapis.com/css?family=Noto+Sans+KR|Noto+Sans+SC&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="lib/fancybox.2.1.5/jquery.fancybox.css" type="text/css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jQuery.mmenu/5.7.8/css/jquery.mmenu.css" type="text/css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jQuery.mmenu/5.7.8/addons/rtl/jquery.mmenu.rtl.css" type="text/css" />


### PR DESCRIPTION
Hi, I've noticed that room labels are rendered in **serif** instead of the desired **sans-serif** if language is set to simplified Chinese or Korean on some os/browser (surprisingly Japanese is rendered correctly; normally if one of these goes wrong then all of them goes wrong).

As in other languages, serif fonts in Chinese are rather hard to read on digital screens, and is especially annoying when put in small clustered labels like in r6maps.

I made a small modification to ensure that Chinese and Korean characters are rendered in Noto Sans, a free cross-language sans-serif font. 

Before the fix:
<img width="1552" alt="before" src="https://user-images.githubusercontent.com/22022191/64081994-3dd89480-ccbd-11e9-9f38-356035956321.png">

After the fix:
<img width="1552" alt="after" src="https://user-images.githubusercontent.com/22022191/64081995-3dd89480-ccbd-11e9-98d1-0e258967f56e.png">

Sans-serif example in Chinese, easier to read on screen
![sans-serif](https://user-images.githubusercontent.com/22022191/64082020-c48d7180-ccbd-11e9-9148-4c3aea8e259f.png)

Serif example in Chinese, easier to read on printed paper
![serif](https://user-images.githubusercontent.com/22022191/64082021-c48d7180-ccbd-11e9-8b9c-a0dabda511d7.png)